### PR TITLE
Slurm job scripts archiver.

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -7,7 +7,7 @@
   ganglia_grid_name: "ExampleSite"
   ganglia_public_name: "ganglia.localdomain"
 
-  enable_openxdmod: true
+  enable_openxdmod: false
 
   xdmod_public_name: "ohpc.novalocal"
 
@@ -40,7 +40,7 @@
 
 # SUPReMM
 
-  enable_supremm: true
+  enable_supremm: false
 
   supremm_url: https://github.com/ubccr/xdmod-supremm/releases/download/v8.1.0/xdmod-supremm-8.1.0-1.0.el7.noarch.rpm
 

--- a/group_vars/all
+++ b/group_vars/all
@@ -67,10 +67,10 @@
   enable_job_archiver: true
   job_archiver_url: https://github.com/eesaanatluri/job_archive.git
   job_archiver_tag: "feat-uabrc-local-changes"
-  job_archiver_path: "/opt/job_archive"
-  job_archiver_bin: "/usr/local/bin/job_archive"
+  job_archiver_path: "/opt/job_archive"             #Path to job_archive repo
+  job_archiver_bin: "/usr/local/bin/job_archive"    #Path to compiled job_archive binary
   job_archiver_user: "slurm"
-  job_archiver_dest: "/var/slurm/jobscript_archive"
+  job_archiver_dest: "/var/slurm/jobscript_archive" #Path to where jobscripts will be archived
 
 # Hierarchy related
 

--- a/group_vars/all
+++ b/group_vars/all
@@ -64,7 +64,7 @@
 
 # Job_archiver related
 
-  enable_job_archiver: true
+  enable_job_archiver: false
   job_archiver_url: https://github.com/eesaanatluri/job_archive.git
   job_archiver_tag: "feat-uabrc-local-changes"
   job_archiver_path: "/opt/job_archive"             #Path to job_archive repo

--- a/roles/job_archiver/templates/job_archiver.service.j2
+++ b/roles/job_archiver/templates/job_archiver.service.j2
@@ -8,7 +8,7 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=5
-ExecStart={{ job_archiver_bin }} -s {{ slurm_state_save_loc }} -t {{ job_archiver_dest }}
+ExecStart={{ job_archiver_bin }} -s {{ slurm_state_save_loc }}/hash. -t {{ job_archiver_dest }}
 User={{ job_archiver_user }}
 
 [Install]


### PR DESCRIPTION
This PR contains tasks required for job_archiver (A tool to store the slurm job scripts submitted to the scheduler for long term. Slurm stores them for a brief time period until the job completion but this job_archiver tool archives them in a dir of our choice) to be deployed in prod.